### PR TITLE
config: add entries for configuring Redis

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,22 @@ import "github.com/NYTimes/gizmo/config"
 type Config struct {
 	*config.Server
 	*config.S3
+	RedisConfig
 
 	EncodingComUserID  string `envconfig:"ENCODINGCOM_USER_ID"`
 	EncodingComUserKey string `envconfig:"ENCODINGCOM_USER_KEY"`
+}
+
+// RedisConfig represents the Redis configuration. RedisAddr and SentinelAddrs
+// configs are exclusive, and the API will prefer to use SentinelAddrs when
+// both are defined.
+type RedisConfig struct {
+	// Comma-separated list of sentinel servers.
+	//
+	// Example: 10.10.10.10:6379,10.10.10.1:6379,10.10.10.2:6379.
+	SentinelAddrs      string `envconfig:"SENTINEL_ADDRS"`
+	SentinelMasterName string `envconfig:"SENTINEL_MASTER_NAME"`
+
+	RedisAddr string `envconfig:"REDIS_ADDR"`
+	Password  string `envconfig:"REDIS_PASSWORD"`
 }


### PR DESCRIPTION
The RedisConfig type will also provide the client instance to
communicate with Redis. In tests, I've added some functions for starting
different Redis server, but the tests still depend on a Redis server
running on 127.0.0.1:6379.
