### PR TITLE
provider: split packages, having one package per provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	gizmoConfig "github.com/NYTimes/gizmo/config"
 	"github.com/NYTimes/gizmo/server"
 	"github.com/nytm/video-transcoding-api/config"
+	_ "github.com/nytm/video-transcoding-api/provider/elastictranscoder"
+	_ "github.com/nytm/video-transcoding-api/provider/encodingcom"
 	"github.com/nytm/video-transcoding-api/service"
 )
 

--- a/provider/elastictranscoder/aws_fake_transcode_test.go
+++ b/provider/elastictranscoder/aws_fake_transcode_test.go
@@ -1,7 +1,9 @@
-package provider
+package elastictranscoder
 
 import (
+	"crypto/rand"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
@@ -30,7 +32,7 @@ func (c *fakeElasticTranscoder) CreateJob(input *elastictranscoder.CreateJobInpu
 	if err := c.getError("CreateJob"); err != nil {
 		return nil, err
 	}
-	id := "job-" + generateID(4)
+	id := fmt.Sprintf("job-%x", generateID())
 	c.jobs[id] = input
 	return &elastictranscoder.CreateJobResponse{
 		Job: &elastictranscoder.Job{
@@ -74,4 +76,10 @@ func (c *fakeElasticTranscoder) getError(op string) error {
 	default:
 	}
 	return nil
+}
+
+func generateID() []byte {
+	var b [4]byte
+	rand.Read(b[:])
+	return b[:]
 }

--- a/provider/encodingcom/encodingcom_server_test.go
+++ b/provider/encodingcom/encodingcom_server_test.go
@@ -1,8 +1,10 @@
-package provider
+package encodingcom
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -75,7 +77,7 @@ func (s *encodingComFakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 func (s *encodingComFakeServer) addMedia(w http.ResponseWriter, req request) {
-	id := generateID(8)
+	id := generateID()
 	created := time.Now().In(time.UTC)
 	s.medias[id] = &fakeMedia{
 		ID:      id,
@@ -137,4 +139,10 @@ func (s *encodingComFakeServer) getMedia(id string) (*fakeMedia, error) {
 		return nil, errMediaNotFound
 	}
 	return media, nil
+}
+
+func generateID() string {
+	var id [8]byte
+	rand.Read(id[:])
+	return fmt.Sprintf("%x", id[:])
 }

--- a/provider/profile.go
+++ b/provider/profile.go
@@ -5,11 +5,6 @@ import (
 	"strconv"
 )
 
-type rotation struct {
-	value uint
-	set   bool
-}
-
 var (
 	// Rotate0Degrees represents 0 degrees rotation (no rotation).
 	Rotate0Degrees = newRotation(0)
@@ -25,11 +20,27 @@ var (
 	Rotate270Degrees = newRotation(270)
 )
 
-func newRotation(n uint) rotation {
-	return rotation{value: n, set: true}
+// Rotation presents rotation configuration in the provider. It's composed by
+// two interval values: the rotation in degrees and whether it has been
+// defined.
+type Rotation struct {
+	value uint
+	set   bool
 }
 
-func (r *rotation) UnmarshalJSON(b []byte) error {
+// Value returns the underlying rotation data.
+func (r Rotation) Value() (uint, bool) {
+	return r.value, r.set
+}
+
+func newRotation(n uint) Rotation {
+	return Rotation{value: n, set: true}
+}
+
+// UnmarshalJSON is the method used for unmarshaling a rotation instance from
+// JSON format. It validates whether this is a valid rotation and  then set the
+// values.
+func (r *Rotation) UnmarshalJSON(b []byte) error {
 	value, err := strconv.ParseUint(string(b), 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid value for rotation: %s. It must be a positive integer", b)
@@ -62,7 +73,7 @@ type Profile struct {
 
 	KeyFrame    string
 	AudioVolume uint
-	Rotate      rotation
+	Rotate      Rotation
 
 	TwoPassEncoding bool
 }

--- a/provider/profile_test.go
+++ b/provider/profile_test.go
@@ -26,9 +26,20 @@ func TestSizeString(t *testing.T) {
 	}
 }
 
+func TestRotationValue(t *testing.T) {
+	rot := Rotation{set: true, value: 10}
+	val, set := rot.Value()
+	if set != rot.set {
+		t.Errorf("Rotation.Value(): got wrong set flag. Want %v. Got %v", rot.set, set)
+	}
+	if val != rot.value {
+		t.Errorf("Rotation.Value(): got wrong value. Want %d. Got %d", rot.value, val)
+	}
+}
+
 func TestRotationVariables(t *testing.T) {
 	var tests = []struct {
-		input    rotation
+		input    Rotation
 		expected uint
 	}{
 		{Rotate0Degrees, 0},
@@ -48,7 +59,7 @@ func TestRotationVariables(t *testing.T) {
 
 func TestRotationUnmarshalJSON(t *testing.T) {
 	var tests = []struct {
-		input       rotation
+		input       Rotation
 		expectedErr error
 	}{
 		{Rotate0Degrees, nil},
@@ -58,7 +69,7 @@ func TestRotationUnmarshalJSON(t *testing.T) {
 		{newRotation(500), errors.New("invalid value for rotation: 500")},
 		{newRotation(3), errors.New("invalid value for rotation: 3")},
 	}
-	var m map[string]rotation
+	var m map[string]Rotation
 	for _, test := range tests {
 		data := []byte(fmt.Sprintf(`{"value": %d}`, test.input.value))
 		err := json.Unmarshal(data, &m)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/nytm/video-transcoding-api/config"
+)
+
+func noopFactory(*config.Config) (TranscodingProvider, error) {
+	return nil, nil
+}
+
+func TestRegister(t *testing.T) {
+	providers = nil
+	err := Register("noop", noopFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := providers["noop"]; !ok {
+		t.Errorf("expected to get the noop factory register. Got map %#v", providers)
+	}
+}
+
+func TestRegisterMultiple(t *testing.T) {
+	providers = nil
+	err := Register("noop", noopFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Register("noope", noopFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := providers["noop"]; !ok {
+		t.Errorf("expected to get the noop factory register. Got map %#v", providers)
+	}
+	if _, ok := providers["noope"]; !ok {
+		t.Errorf("expected to get the noope factory register. Got map %#v", providers)
+	}
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	providers = nil
+	err := Register("noop", noopFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Register("noop", noopFactory)
+	if err != ErrProviderAlreadyRegistered {
+		t.Errorf("Got wrong error when registering provider twice. Want %#v. Got %#v", ErrProviderAlreadyRegistered, err)
+	}
+}
+
+func TestGetProviderFactory(t *testing.T) {
+	providers = nil
+	var called bool
+	err := Register("noop", func(*config.Config) (TranscodingProvider, error) {
+		called = true
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory, err := GetProviderFactory("noop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory(nil)
+	if !called {
+		t.Errorf("Did not call the expected factory. Got %#v", factory)
+	}
+}
+
+func TestGetProviderFactoryNotRegistered(t *testing.T) {
+	providers = nil
+	factory, err := GetProviderFactory("noop")
+	if factory != nil {
+		t.Errorf("Got unexpected non-nil factory: %#v", factory)
+	}
+	if err != ErrProviderNotFound {
+		t.Errorf("Got wrong error when getting an unregistered provider. Want %#v. Got %#v", ErrProviderNotFound, err)
+	}
+}

--- a/service/fake_provider_test.go
+++ b/service/fake_provider_test.go
@@ -5,6 +5,12 @@ import (
 	"github.com/nytm/video-transcoding-api/provider"
 )
 
+func init() {
+	provider.Register("fake", fakeProviderFactory)
+	provider.Register("profile-fake", profileFakeProviderFactory)
+	provider.Register("preset-fake", presetFakeProviderFactory)
+}
+
 type baseFakeProvider struct{}
 
 func (e *baseFakeProvider) JobStatus(id string) (*provider.JobStatus, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -9,15 +9,13 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/nytm/video-transcoding-api/config"
 	"github.com/nytm/video-transcoding-api/db"
-	"github.com/nytm/video-transcoding-api/provider"
 )
 
 // TranscodingService will implement server.JSONService and handle all requests
 // to the server.
 type TranscodingService struct {
-	config    *config.Config
-	db        db.JobRepository
-	providers map[string]provider.Factory
+	config *config.Config
+	db     db.JobRepository
 }
 
 // NewTranscodingService will instantiate a JSONService
@@ -27,14 +25,7 @@ func NewTranscodingService(cfg *config.Config) (*TranscodingService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing Redis client: %s", err)
 	}
-	return &TranscodingService{
-		config: cfg,
-		db:     dbRepo,
-		providers: map[string]provider.Factory{
-			"encoding.com":      provider.EncodingComProvider,
-			"elastictranscoder": provider.ElasticTranscoderProvider,
-		},
-	}, nil
+	return &TranscodingService{config: cfg, db: dbRepo}, nil
 }
 
 // Prefix returns the string prefix used for all endpoints within

--- a/service/transcode.go
+++ b/service/transcode.go
@@ -37,9 +37,9 @@ func (s *TranscodingService) newTranscodeJob(r *http.Request) (int, interface{},
 	if len(reqObject.Profiles) > 0 && len(reqObject.Presets) > 0 {
 		return http.StatusBadRequest, nil, errors.New("Presets and profiles are mutually exclusive, please use only one of them")
 	}
-	providerFactory := s.providers[reqObject.Provider]
-	if providerFactory == nil {
-		return http.StatusBadRequest, nil, fmt.Errorf("Unknown provider found in request: %s", reqObject.Provider)
+	providerFactory, err := provider.GetProviderFactory(reqObject.Provider)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
 	}
 	providerObj, err := providerFactory(s.config)
 	if err != nil {
@@ -89,8 +89,8 @@ func (s *TranscodingService) getTranscodeJob(r *http.Request) (int, interface{},
 		}
 		return statusCode, nil, fmt.Errorf("Error retrieving job with id '%s': %s", jobID, err)
 	}
-	providerFactory := s.providers[job.ProviderName]
-	if providerFactory == nil {
+	providerFactory, err := provider.GetProviderFactory(job.ProviderName)
+	if err != nil {
 		return http.StatusInternalServerError, nil, fmt.Errorf("Unknown provider '%s' for job id '%s'", job.ProviderName, jobID)
 	}
 	providerObj, err := providerFactory(s.config)

--- a/service/transcode_test.go
+++ b/service/transcode_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/NYTimes/gizmo/server"
 	"github.com/nytm/video-transcoding-api/config"
 	"github.com/nytm/video-transcoding-api/db"
-	"github.com/nytm/video-transcoding-api/provider"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -133,7 +132,7 @@ func TestTranscode(t *testing.T) {
 
 			http.StatusBadRequest,
 			map[string]interface{}{
-				"error": "Unknown provider found in request: nonexistent-provider",
+				"error": "provider not found",
 			},
 		},
 		{
@@ -203,15 +202,7 @@ func TestTranscode(t *testing.T) {
 		fakeDBObj := db.JobRepository(&fakeDB{
 			TriggerDBError: test.givenTriggerDBError,
 		})
-		srvr.Register(&TranscodingService{
-			config: &config.Config{},
-			db:     fakeDBObj,
-			providers: map[string]provider.Factory{
-				"fake":         fakeProviderFactory,
-				"profile-fake": profileFakeProviderFactory,
-				"preset-fake":  presetFakeProviderFactory,
-			},
-		})
+		srvr.Register(&TranscodingService{config: &config.Config{}, db: fakeDBObj})
 		r, _ := http.NewRequest("POST", "/jobs", strings.NewReader(test.givenRequestBody))
 		r.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -275,11 +266,7 @@ func TestGetTranscodeJob(t *testing.T) {
 		fakeDBObj := db.JobRepository(&fakeDB{
 			TriggerDBError: test.givenTriggerDBError,
 		})
-		srvr.Register(&TranscodingService{
-			config:    &config.Config{},
-			db:        fakeDBObj,
-			providers: map[string]provider.Factory{"fake": fakeProviderFactory},
-		})
+		srvr.Register(&TranscodingService{config: &config.Config{}, db: fakeDBObj})
 		r, _ := http.NewRequest("GET", test.givenURI, nil)
 		r.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()


### PR DESCRIPTION
It has impact on the way we handle multiple providers. Here are the
roles of each package:
- provider: this package defines the TranscodingProvider interface, and
  also stores an internal registry of providers. Providers can be
  registered using the Register function, and users willing to use a
  provider can get the factory instance using the GetProviderFactory
  function
- provider/elastictranscoder, provider/encodingcom: these packages
  contain the implementation of each provider, and automatically
  register they underlying provider in the registry when imported
- service: this package will now just query the provider registry to
  get the provider factory. It no longer constructs an internal map of
  provider factories
- main: in order to get all providers registered, the main package will
  import them. In order to prevent compilation errors, the ignore
  expression is used (that _ right before the import path)
