### PR TITLE
bin/build: change build options

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -8,22 +8,21 @@ fi
 
 # Create a temporary GOPATH
 export GOTMP=/tmp/video-transcoding-api-$RANDOM
-mkdir -p $GOTMP
 
 # And a place to dump the output
 export OUTPUT=$GOTMP/output
 
 # Copy the current directory into the GOPATH
 export CODE=$GOTMP/src/github.com/nytm/video-transcoding-api
-mkdir -p `dirname "$CODE"`
+mkdir -p $CODE
 cp -R . $CODE
 
 # Download dependencies and build
 pushd $CODE
-GOPATH=$GOTMP go get -t
-GOPATH=$GOTMP go test
+GOPATH=$GOTMP go get -d
 GOPATH=$GOTMP GOARCH=amd64 GOOS=linux go build -o $OUTPUT/video-transcoding-api
 cp config.json $OUTPUT/.
+cp swagger.json $OUTPUT/.
 popd
 
 # Create the output tarball


### PR DESCRIPTION
Do not compile dependencies when downloading then (the flag -d means
"download only"), and do not download test dependencies. We're not going
to run tests for now. I understand the impact of that: since we're
blindly running `go get`, we're always downloading the latest version of
our dependencies, so running tests is a safe path. I still think that an
even safer path is to have dependencies vendored, so might be something
that we tackle in the future.

I've also included the swagger.json file in the tarball.
