### PR TITLE
bin/build: speed-up local build time

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -17,10 +17,14 @@ export CODE=$GOTMP/src/github.com/nytm/video-transcoding-api
 mkdir -p $CODE
 cp -R . $CODE
 
+if [ -z "$GOPATH" ]; then
+  export GOPATH=$GOTMP
+fi
+
 # Download dependencies and build
 pushd $CODE
-GOPATH=$GOTMP go get -d
-GOPATH=$GOTMP GOARCH=amd64 GOOS=linux go build -o $OUTPUT/video-transcoding-api
+go get -d
+GOARCH=amd64 GOOS=linux go build -o $OUTPUT/video-transcoding-api
 cp config.json $OUTPUT/.
 cp swagger.json $OUTPUT/.
 popd


### PR DESCRIPTION
In case we have GOPATH defined, we probably have the dependencies, than
we don't need to download them again. It still works as expected in a
box with no GOPATH defined.

It's way faster to avoid downloading the dependencies. This is because
`go get` is dumb when cloning Git repositories. This should probably
change when golang/go#13078 is fixed (Go 1.7, hopefully).
