### PR TITLE
Include id of the job in the output folder

### DIFF
--- a/db/dbtest/fake_db.go
+++ b/db/dbtest/fake_db.go
@@ -27,9 +27,6 @@ func (d *fakeRepository) CreateJob(job *db.Job) error {
 	if d.triggerError {
 		return errors.New("database error")
 	}
-	if job.ID == "" {
-		job.ID = "12345"
-	}
 	if job.CreationTime.IsZero() {
 		job.CreationTime = time.Now().UTC()
 	}

--- a/db/dbtest/fake_db_test.go
+++ b/db/dbtest/fake_db_test.go
@@ -41,24 +41,6 @@ func TestCreateJobPredefinedDate(t *testing.T) {
 	}
 }
 
-func TestCreateJobNoID(t *testing.T) {
-	repo := NewFakeRepository(false)
-	job := db.Job{ProviderName: "myprovider"}
-	err := repo.CreateJob(&job)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if job.CreationTime.IsZero() {
-		t.Error("Did not set the CreationTime")
-	}
-	if job.CreationTime.Location() != time.UTC {
-		t.Errorf("Did not set CreationTime to UTC: %#v", job.CreationTime.Location())
-	}
-	if job.ID != "12345" {
-		t.Errorf("Did not generate an ID. Want 12345. Got %q", job.ID)
-	}
-}
-
 func TestCreateJobDBError(t *testing.T) {
 	repo := NewFakeRepository(true)
 	job := db.Job{ProviderName: "myprovider"}

--- a/db/redis/job.go
+++ b/db/redis/job.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
@@ -12,11 +13,7 @@ const jobsSetKey = "jobs"
 
 func (r *redisRepository) CreateJob(job *db.Job) error {
 	if job.ID == "" {
-		jobID, err := r.generateID()
-		if err != nil {
-			return err
-		}
-		job.ID = jobID
+		return errors.New("job id is required")
 	}
 	job.CreationTime = time.Now().UTC()
 	return r.saveJob(job)

--- a/db/redis/redis.go
+++ b/db/redis/redis.go
@@ -1,10 +1,8 @@
 package redis
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"reflect"
@@ -250,18 +248,6 @@ func (r *redisRepository) delete(key string, notFoundErr error) error {
 		return notFoundErr
 	}
 	return nil
-}
-
-func (r *redisRepository) generateID() (string, error) {
-	var raw [8]byte
-	n, err := rand.Read(raw[:])
-	if err != nil {
-		return "", err
-	}
-	if n != 8 {
-		return "", io.ErrShortWrite
-	}
-	return fmt.Sprintf("%x", raw), nil
 }
 
 func (r *redisRepository) redisClient() *redis.Client {

--- a/provider/elastictranscoder/aws_test.go
+++ b/provider/elastictranscoder/aws_test.go
@@ -164,7 +164,7 @@ func TestAWSTranscode(t *testing.T) {
 		Presets:         presetmaps,
 		StreamingParams: provider.StreamingParams{},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,9 +187,9 @@ func TestAWSTranscode(t *testing.T) {
 		PipelineId: aws.String("mypipeline"),
 		Input:      &elastictranscoder.JobInput{Key: aws.String(source)},
 		Outputs: []*elastictranscoder.CreateJobOutput{
-			{PresetId: aws.String("93239832-0001"), Key: aws.String("dir/mp4_720p/file.mp4")},
-			{PresetId: aws.String("93239832-0002"), Key: aws.String("dir/webm_720p/file.webm")},
-			{PresetId: aws.String("93239832-0003"), Key: aws.String("dir/mov_1080p/file.mov")},
+			{PresetId: aws.String("93239832-0001"), Key: aws.String("job-123/dir/mp4_720p/file.mp4")},
+			{PresetId: aws.String("93239832-0002"), Key: aws.String("job-123/dir/webm_720p/file.webm")},
+			{PresetId: aws.String("93239832-0003"), Key: aws.String("job-123/dir/mov_1080p/file.mov")},
 		},
 	}
 	if !reflect.DeepEqual(*jobInput, expectedJobInput) {
@@ -242,7 +242,7 @@ func TestAWSTranscodeAdaptiveStreaming(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{Protocol: "hls", SegmentDuration: 3},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,18 +265,18 @@ func TestAWSTranscodeAdaptiveStreaming(t *testing.T) {
 		PipelineId: aws.String("mypipeline"),
 		Input:      &elastictranscoder.JobInput{Key: aws.String(source)},
 		Outputs: []*elastictranscoder.CreateJobOutput{
-			{PresetId: aws.String("93239832-0001"), Key: aws.String("dir/file/hls_360p/video"), SegmentDuration: aws.String("3")},
-			{PresetId: aws.String("93239832-0002"), Key: aws.String("dir/file/hls_480p/video"), SegmentDuration: aws.String("3")},
-			{PresetId: aws.String("93239832-0003"), Key: aws.String("dir/file/hls_720p/video"), SegmentDuration: aws.String("3")},
+			{PresetId: aws.String("93239832-0001"), Key: aws.String("job-123/dir/file/hls_360p/video"), SegmentDuration: aws.String("3")},
+			{PresetId: aws.String("93239832-0002"), Key: aws.String("job-123/dir/file/hls_480p/video"), SegmentDuration: aws.String("3")},
+			{PresetId: aws.String("93239832-0003"), Key: aws.String("job-123/dir/file/hls_720p/video"), SegmentDuration: aws.String("3")},
 		},
 		Playlists: []*elastictranscoder.CreateJobPlaylist{
 			{
 				Format: aws.String("HLSv3"),
 				Name:   aws.String("dir/file/master"),
 				OutputKeys: []*string{
-					aws.String("dir/file/hls_360p/video"),
-					aws.String("dir/file/hls_480p/video"),
-					aws.String("dir/file/hls_720p/video"),
+					aws.String("job-123/dir/file/hls_360p/video"),
+					aws.String("job-123/dir/file/hls_480p/video"),
+					aws.String("job-123/dir/file/hls_720p/video"),
 				},
 			},
 		},
@@ -321,7 +321,7 @@ func TestAWSTranscodeNormalizedSource(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-1"}, transcodeProfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,8 +344,8 @@ func TestAWSTranscodeNormalizedSource(t *testing.T) {
 		PipelineId: aws.String("mypipeline"),
 		Input:      &elastictranscoder.JobInput{Key: aws.String("some/dir/with/subdir/file.mov")},
 		Outputs: []*elastictranscoder.CreateJobOutput{
-			{PresetId: aws.String("93239832-0001"), Key: aws.String("some/dir/with/subdir/mp4_720p/file.mp4")},
-			{PresetId: aws.String("93239832-0002"), Key: aws.String("some/dir/with/subdir/hls_1080p/file.ts")},
+			{PresetId: aws.String("93239832-0001"), Key: aws.String("job-1/some/dir/with/subdir/mp4_720p/file.mp4")},
+			{PresetId: aws.String("93239832-0002"), Key: aws.String("job-1/some/dir/with/subdir/hls_1080p/file.ts")},
 		},
 	}
 	if !reflect.DeepEqual(*jobInput, expectedJobInput) {
@@ -377,7 +377,7 @@ func TestAWSTranscodePresetNotFound(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if err != provider.ErrPresetMapNotFound {
 		t.Errorf("Wrong error returned. Want %#v. Got %#v", provider.ErrPresetMapNotFound, err)
 	}
@@ -405,7 +405,7 @@ func TestAWSTranscodeAWSFailureInAmazon(t *testing.T) {
 		Presets:         nil,
 		StreamingParams: provider.StreamingParams{},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if jobStatus != nil {
 		t.Errorf("Got unexpected non-nil status: %#v", jobStatus)
 	}
@@ -449,7 +449,7 @@ func TestAWSJobStatus(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{},
 	}
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -463,11 +463,11 @@ func TestAWSJobStatus(t *testing.T) {
 		Status:        provider.StatusFinished,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{
-				"dir/mp4_720p/file.mp4":   "it's finished!",
-				"dir/webm_720p/file.webm": "it's finished!",
+				"job-123/dir/mp4_720p/file.mp4":   "it's finished!",
+				"job-123/dir/webm_720p/file.webm": "it's finished!",
 			},
 		},
-		OutputDestination: "s3://some bucket/dir",
+		OutputDestination: "s3://some bucket/job-123/dir",
 	}
 	if !reflect.DeepEqual(*jobStatus, expectedJobStatus) {
 		t.Errorf("Wrong JobStatus. Want %#v. Got %#v.", expectedJobStatus, *jobStatus)

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -125,7 +125,7 @@ func TestElementalNewJob(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{},
 	}
-	newJob, err := presetProvider.newJob(transcodeProfile)
+	newJob, err := presetProvider.newJob(&db.Job{ID: "job-1"}, transcodeProfile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -145,7 +145,7 @@ func TestElementalNewJob(t *testing.T) {
 			Order: 1,
 			FileGroupSettings: &elementalconductor.FileGroupSettings{
 				Destination: &elementalconductor.Location{
-					URI:      "s3://destination/video",
+					URI:      "s3://destination/job-1/video",
 					Username: "aws-access-key",
 					Password: "aws-secret-key",
 				},
@@ -243,7 +243,7 @@ func TestElementalNewJobAdaptiveStreaming(t *testing.T) {
 			SegmentDuration: 3,
 		},
 	}
-	newJob, err := presetProvider.newJob(transcodeProfile)
+	newJob, err := presetProvider.newJob(&db.Job{ID: "job-2"}, transcodeProfile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -263,7 +263,7 @@ func TestElementalNewJobAdaptiveStreaming(t *testing.T) {
 			Order: 1,
 			AppleLiveGroupSettings: &elementalconductor.AppleLiveGroupSettings{
 				Destination: &elementalconductor.Location{
-					URI:      "s3://destination/video",
+					URI:      "s3://destination/job-2/video",
 					Username: "aws-access-key",
 					Password: "aws-secret-key",
 				},
@@ -354,7 +354,7 @@ func TestElementalNewJobPresetNotFound(t *testing.T) {
 		Presets:         presets,
 		StreamingParams: provider.StreamingParams{},
 	}
-	newJob, err := presetProvider.newJob(transcodeProfile)
+	newJob, err := presetProvider.newJob(&db.Job{ID: "job-2"}, transcodeProfile)
 	if err != provider.ErrPresetMapNotFound {
 		t.Errorf("Wrong error returned. Want %#v. Got %#v", provider.ErrPresetMapNotFound, err)
 	}

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -126,7 +126,7 @@ func TestEncodingComTranscode(t *testing.T) {
 		},
 	}
 
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,27 +144,27 @@ func TestEncodingComTranscode(t *testing.T) {
 	expectedFormats := []encodingcom.Format{
 		{
 			Output:          []string{"123455"},
-			Destination:     []string{dest + "webm_720p/video.webm"},
+			Destination:     []string{dest + "job-123/webm_720p/video.webm"},
 			SegmentDuration: 3,
 		},
 		{
 			Output:          []string{"123456"},
-			Destination:     []string{dest + "webm_480p/video.webm"},
+			Destination:     []string{dest + "job-123/webm_480p/video.webm"},
 			SegmentDuration: 3,
 		},
 		{
 			Output:          []string{"321321"},
-			Destination:     []string{dest + "mp4_1080p/video.mp4"},
+			Destination:     []string{dest + "job-123/mp4_1080p/video.mp4"},
 			SegmentDuration: 3,
 		},
 		{
 			Output:          []string{"321322"},
-			Destination:     []string{dest + "hls_1080p/video/master.m3u8"},
+			Destination:     []string{dest + "job-123/hls_1080p/video/master.m3u8"},
 			SegmentDuration: 3,
 		},
 	}
 	if !reflect.DeepEqual(media.Request.Format, expectedFormats) {
-		t.Errorf("Wrong format. Want %#v. Got %#v.", expectedFormats, media.Request.Format)
+		t.Errorf("Wrong format.\nWant %#v\nGot  %#v.", expectedFormats, media.Request.Format)
 	}
 	if !reflect.DeepEqual([]string{source}, media.Request.Source) {
 		t.Errorf("Wrong source. Want %v. Got %v.", []string{source}, media.Request.Source)
@@ -210,7 +210,7 @@ func TestEncodingComTranscodePresetNotFound(t *testing.T) {
 		},
 	}
 
-	jobStatus, err := prov.Transcode(transcodeProfile)
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-2"}, transcodeProfile)
 	if err != provider.ErrPresetMapNotFound {
 		t.Errorf("Wrong error. Want %#v. Got %#v", provider.ErrPresetMapNotFound, err)
 	}

--- a/provider/fake_provider_test.go
+++ b/provider/fake_provider_test.go
@@ -1,13 +1,16 @@
 package provider
 
-import "github.com/nytm/video-transcoding-api/config"
+import (
+	"github.com/nytm/video-transcoding-api/config"
+	"github.com/nytm/video-transcoding-api/db"
+)
 
 type fakeProvider struct {
 	cap       Capabilities
 	healthErr error
 }
 
-func (*fakeProvider) Transcode(TranscodeProfile) (*JobStatus, error) {
+func (*fakeProvider) Transcode(*db.Job, TranscodeProfile) (*JobStatus, error) {
 	return nil, nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,9 +29,9 @@ var (
 // Job. The underlying provider should handle the profileSpec as desired (it
 // might be a JSON, or an XML, or anything else.
 type TranscodingProvider interface {
-	Transcode(transcodeProfile TranscodeProfile) (*JobStatus, error)
+	Transcode(*db.Job, TranscodeProfile) (*JobStatus, error)
 	JobStatus(id string) (*JobStatus, error)
-	CreatePreset(preset Preset) (string, error)
+	CreatePreset(Preset) (string, error)
 	DeletePreset(presetID string) error
 
 	// Healthcheck should return nil if the provider is currently available

--- a/service/fake_provider_test.go
+++ b/service/fake_provider_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/nytm/video-transcoding-api/config"
+	"github.com/nytm/video-transcoding-api/db"
 	"github.com/nytm/video-transcoding-api/provider"
 )
 
@@ -11,7 +12,7 @@ func init() {
 
 type fakeProvider struct{}
 
-func (p *fakeProvider) Transcode(transcodeProfile provider.TranscodeProfile) (*provider.JobStatus, error) {
+func (p *fakeProvider) Transcode(job *db.Job, transcodeProfile provider.TranscodeProfile) (*provider.JobStatus, error) {
 	for _, preset := range transcodeProfile.Presets {
 		if _, ok := preset.ProviderMapping["fake"]; !ok {
 			return nil, provider.ErrPresetMapNotFound


### PR DESCRIPTION
This required some changes to the way our code behave: instead of
generating the id in the repository layer, we now do that in the service
layer, and the job is now provided as a parameter to the Transcode
method, so the provider can use its id to build the output destination.
