### PR TITLE
Support jobs with adaptive and non-adaptive streaming presets

### DIFF
--- a/provider/elastictranscoder/aws_fake_transcode_test.go
+++ b/provider/elastictranscoder/aws_fake_transcode_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
@@ -55,6 +56,20 @@ func (c *fakeElasticTranscoder) CreatePreset(input *elastictranscoder.CreatePres
 			Id:          &presetID,
 			Thumbnails:  input.Thumbnails,
 			Video:       input.Video,
+		},
+	}, nil
+}
+
+func (c *fakeElasticTranscoder) ReadPreset(input *elastictranscoder.ReadPresetInput) (*elastictranscoder.ReadPresetOutput, error) {
+	container := "mp4"
+	if strings.Contains(*input.Id, "hls") {
+		container = "ts"
+	}
+	return &elastictranscoder.ReadPresetOutput{
+		Preset: &elastictranscoder.Preset{
+			Id:        input.Id,
+			Name:      input.Id,
+			Container: aws.String(container),
 		},
 	}, nil
 }

--- a/provider/elementalconductor/elementalconductor_fake_transcode_test.go
+++ b/provider/elementalconductor/elementalconductor_fake_transcode_test.go
@@ -1,0 +1,77 @@
+package elementalconductor
+
+import (
+	"strings"
+
+	"github.com/NYTimes/encoding-wrapper/elementalconductor"
+	"github.com/nytm/video-transcoding-api/config"
+	"github.com/nytm/video-transcoding-api/provider"
+)
+
+type fakeElementalConductorClient struct {
+	*elementalconductor.Client
+}
+
+func newFakeElementalConductorClient(cfg *config.Config) *fakeElementalConductorClient {
+	return &fakeElementalConductorClient{
+		Client: &elementalconductor.Client{
+			Host:            cfg.ElementalConductor.Host,
+			UserLogin:       cfg.ElementalConductor.UserLogin,
+			APIKey:          cfg.ElementalConductor.APIKey,
+			AuthExpires:     cfg.ElementalConductor.AuthExpires,
+			AccessKeyID:     cfg.ElementalConductor.AccessKeyID,
+			SecretAccessKey: cfg.ElementalConductor.SecretAccessKey,
+			Destination:     cfg.ElementalConductor.Destination,
+		},
+	}
+}
+
+func (c *fakeElementalConductorClient) GetAccessKeyID() string {
+	return c.AccessKeyID
+}
+func (c *fakeElementalConductorClient) GetSecretAccessKey() string {
+	return c.SecretAccessKey
+}
+func (c *fakeElementalConductorClient) GetDestination() string {
+	return c.Destination
+}
+
+func (c *fakeElementalConductorClient) GetPreset(presetID string) (*elementalconductor.Preset, error) {
+	container := elementalconductor.MPEG4
+	if strings.Contains(presetID, "hls") {
+		container = elementalconductor.AppleHTTPLiveStreaming
+	}
+	return &elementalconductor.Preset{
+		Name:      presetID,
+		Container: string(container),
+	}, nil
+}
+func (c *fakeElementalConductorClient) CreatePreset(preset *elementalconductor.Preset) (*elementalconductor.Preset, error) {
+	return &elementalconductor.Preset{
+		Name: preset.Name,
+	}, nil
+}
+func (c *fakeElementalConductorClient) DeletePreset(presetID string) error {
+	return nil
+}
+func (c *fakeElementalConductorClient) CreateJob(job *elementalconductor.Job) (*elementalconductor.Job, error) {
+	return &elementalconductor.Job{}, nil
+}
+func (c *fakeElementalConductorClient) GetJob(jobID string) (*elementalconductor.Job, error) {
+	return &elementalconductor.Job{}, nil
+}
+func (c *fakeElementalConductorClient) GetNodes() ([]elementalconductor.Node, error) {
+	return []elementalconductor.Node{}, nil
+}
+func (c *fakeElementalConductorClient) GetCloudConfig() (*elementalconductor.CloudConfig, error) {
+	return &elementalconductor.CloudConfig{}, nil
+}
+
+func fakeElementalConductorFactory(cfg *config.Config) (provider.TranscodingProvider, error) {
+	if cfg.ElementalConductor.Host == "" || cfg.ElementalConductor.UserLogin == "" ||
+		cfg.ElementalConductor.APIKey == "" || cfg.ElementalConductor.AuthExpires == 0 {
+		return nil, errElementalConductorInvalidConfig
+	}
+	client := newFakeElementalConductorClient(cfg)
+	return &elementalConductorProvider{client: client, config: cfg}, nil
+}

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -35,14 +35,14 @@ func TestElementalConductorFactory(t *testing.T) {
 	if !ok {
 		t.Fatalf("Wrong provider returned. Want elementalConductorProvider instance. Got %#v.", provider)
 	}
-	expected := elementalconductor.Client{
+	expected := &elementalconductor.Client{
 		Host:        "elemental-server",
 		UserLogin:   "myuser",
 		APIKey:      "secret-key",
 		AuthExpires: 30,
 	}
-	if !reflect.DeepEqual(*econductorProvider.client, expected) {
-		t.Errorf("Factory: wrong client returned. Want %#v. Got %#v.", expected, *econductorProvider.client)
+	if !reflect.DeepEqual(econductorProvider.client, expected) {
+		t.Errorf("Factory: wrong client returned. Want %#v. Got %#v.", expected, econductorProvider.client)
 	}
 	if !reflect.DeepEqual(*econductorProvider.config, cfg) {
 		t.Errorf("Factory: wrong config returned. Want %#v. Got %#v.", cfg, *econductorProvider.config)
@@ -93,7 +93,7 @@ func TestElementalNewJob(t *testing.T) {
 			Destination:     "s3://destination",
 		},
 	}
-	prov, err := elementalConductorFactory(&elementalConductorConfig)
+	prov, err := fakeElementalConductorFactory(&elementalConductorConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,17 +105,17 @@ func TestElementalNewJob(t *testing.T) {
 	presets := []db.PresetMap{
 		{
 			Name:            "webm_720p",
-			ProviderMapping: map[string]string{Name: "10", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "webm_720p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: "webm"},
 		},
 		{
 			Name:            "mp4_720p",
-			ProviderMapping: map[string]string{Name: "15", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "mp4_720p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: "mp4"},
 		},
 		{
 			Name:            "mp4_1080p",
-			ProviderMapping: map[string]string{Name: "20", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "mp4_1080p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: ""},
 		},
 	}
@@ -141,49 +141,51 @@ func TestElementalNewJob(t *testing.T) {
 			},
 		},
 		Priority: 50,
-		OutputGroup: elementalconductor.OutputGroup{
-			Order: 1,
-			FileGroupSettings: &elementalconductor.FileGroupSettings{
-				Destination: &elementalconductor.Location{
-					URI:      "s3://destination/job-1/video",
-					Username: "aws-access-key",
-					Password: "aws-secret-key",
+		OutputGroup: []elementalconductor.OutputGroup{
+			{
+				Order: 1,
+				FileGroupSettings: &elementalconductor.FileGroupSettings{
+					Destination: &elementalconductor.Location{
+						URI:      "s3://destination/job-1/video",
+						Username: "aws-access-key",
+						Password: "aws-secret-key",
+					},
 				},
-			},
-			Type: elementalconductor.FileOutputGroupType,
-			Output: []elementalconductor.Output{
-				{
-					StreamAssemblyName: "stream_0",
-					NameModifier:       "_webm_720p",
-					Order:              0,
-					Container:          elementalconductor.Container("webm"),
-				},
-				{
-					StreamAssemblyName: "stream_1",
-					NameModifier:       "_mp4_720p",
-					Order:              1,
-					Container:          elementalconductor.MPEG4,
-				},
-				{
-					StreamAssemblyName: "stream_2",
-					NameModifier:       "_mp4_1080p",
-					Order:              2,
-					Container:          "",
+				Type: elementalconductor.FileOutputGroupType,
+				Output: []elementalconductor.Output{
+					{
+						StreamAssemblyName: "stream_0",
+						NameModifier:       "_webm_720p",
+						Order:              0,
+						Container:          elementalconductor.Container("webm"),
+					},
+					{
+						StreamAssemblyName: "stream_1",
+						NameModifier:       "_mp4_720p",
+						Order:              1,
+						Container:          elementalconductor.MPEG4,
+					},
+					{
+						StreamAssemblyName: "stream_2",
+						NameModifier:       "_mp4_1080p",
+						Order:              2,
+						Container:          "",
+					},
 				},
 			},
 		},
 		StreamAssembly: []elementalconductor.StreamAssembly{
 			{
 				Name:   "stream_0",
-				Preset: "10",
+				Preset: "webm_720p",
 			},
 			{
 				Name:   "stream_1",
-				Preset: "15",
+				Preset: "mp4_720p",
 			},
 			{
 				Name:   "stream_2",
-				Preset: "20",
+				Preset: "mp4_1080p",
 			},
 		},
 	}
@@ -204,7 +206,7 @@ func TestElementalNewJobAdaptiveStreaming(t *testing.T) {
 			Destination:     "s3://destination",
 		},
 	}
-	prov, err := elementalConductorFactory(&elementalConductorConfig)
+	prov, err := fakeElementalConductorFactory(&elementalConductorConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,22 +218,22 @@ func TestElementalNewJobAdaptiveStreaming(t *testing.T) {
 	presets := []db.PresetMap{
 		{
 			Name:            "hls_360p",
-			ProviderMapping: map[string]string{Name: "15", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "hls_360p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: "hls"},
 		},
 		{
 			Name:            "hls_480p",
-			ProviderMapping: map[string]string{Name: "20", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "hls_480p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: "ts"},
 		},
 		{
 			Name:            "hls_720p",
-			ProviderMapping: map[string]string{Name: "25", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "hls_720p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: "m3u8"},
 		},
 		{
 			Name:            "hls_1080p",
-			ProviderMapping: map[string]string{Name: "30", "other": "not relevant"},
+			ProviderMapping: map[string]string{Name: "hls_1080p", "other": "not relevant"},
 			OutputOpts:      db.OutputOptions{Extension: ".ts"},
 		},
 	}
@@ -259,65 +261,256 @@ func TestElementalNewJobAdaptiveStreaming(t *testing.T) {
 			},
 		},
 		Priority: 50,
-		OutputGroup: elementalconductor.OutputGroup{
-			Order: 1,
-			AppleLiveGroupSettings: &elementalconductor.AppleLiveGroupSettings{
-				Destination: &elementalconductor.Location{
-					URI:      "s3://destination/job-2/video",
-					Username: "aws-access-key",
-					Password: "aws-secret-key",
+		OutputGroup: []elementalconductor.OutputGroup{
+			{
+				Order: 1,
+				AppleLiveGroupSettings: &elementalconductor.AppleLiveGroupSettings{
+					Destination: &elementalconductor.Location{
+						URI:      "s3://destination/job-2/video",
+						Username: "aws-access-key",
+						Password: "aws-secret-key",
+					},
+					SegmentDuration: 3,
 				},
-				SegmentDuration: 3,
-			},
-			Type: elementalconductor.AppleLiveOutputGroupType,
-			Output: []elementalconductor.Output{
-				{
-					StreamAssemblyName: "stream_0",
-					NameModifier:       "_hls_360p",
-					Order:              0,
-					Container:          elementalconductor.AppleHTTPLiveStreaming,
-				},
-				{
-					StreamAssemblyName: "stream_1",
-					NameModifier:       "_hls_480p",
-					Order:              1,
-					Container:          elementalconductor.AppleHTTPLiveStreaming,
-				},
-				{
-					StreamAssemblyName: "stream_2",
-					NameModifier:       "_hls_720p",
-					Order:              2,
-					Container:          elementalconductor.AppleHTTPLiveStreaming,
-				},
-				{
-					StreamAssemblyName: "stream_3",
-					NameModifier:       "_hls_1080p",
-					Order:              3,
-					Container:          elementalconductor.AppleHTTPLiveStreaming,
+				Type: elementalconductor.AppleLiveOutputGroupType,
+				Output: []elementalconductor.Output{
+					{
+						StreamAssemblyName: "stream_0",
+						NameModifier:       "_hls_360p",
+						Order:              0,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_1",
+						NameModifier:       "_hls_480p",
+						Order:              1,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_2",
+						NameModifier:       "_hls_720p",
+						Order:              2,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_3",
+						NameModifier:       "_hls_1080p",
+						Order:              3,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
 				},
 			},
 		},
 		StreamAssembly: []elementalconductor.StreamAssembly{
 			{
 				Name:   "stream_0",
-				Preset: "15",
+				Preset: "hls_360p",
 			},
 			{
 				Name:   "stream_1",
-				Preset: "20",
+				Preset: "hls_480p",
 			},
 			{
 				Name:   "stream_2",
-				Preset: "25",
+				Preset: "hls_720p",
 			},
 			{
 				Name:   "stream_3",
-				Preset: "30",
+				Preset: "hls_1080p",
 			},
 		},
 	}
 	if !reflect.DeepEqual(&expectedJob, newJob) {
 		t.Errorf("New adaptive bitrate job not according to spec.\nWanted %#v.\nGot    %#v.", &expectedJob, newJob)
+	}
+}
+
+func TestElementalNewJobAdaptiveAndNonAdaptiveStreaming(t *testing.T) {
+	elementalConductorConfig := config.Config{
+		ElementalConductor: &config.ElementalConductor{
+			Host:            "https://mybucket.s3.amazonaws.com/destination-dir/",
+			UserLogin:       "myuser",
+			APIKey:          "elemental-api-key",
+			AuthExpires:     30,
+			AccessKeyID:     "aws-access-key",
+			SecretAccessKey: "aws-secret-key",
+			Destination:     "s3://destination",
+		},
+	}
+	prov, err := fakeElementalConductorFactory(&elementalConductorConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	presetProvider, ok := prov.(*elementalConductorProvider)
+	if !ok {
+		t.Fatal("Could not type assert test provider to elementalConductorProvider")
+	}
+	source := "http://some.nice/video.mov"
+	presets := []db.PresetMap{
+		{
+			Name:            "webm_720p",
+			ProviderMapping: map[string]string{Name: "webm_720p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: "webm"},
+		},
+		{
+			Name:            "mp4_720p",
+			ProviderMapping: map[string]string{Name: "mp4_720p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: "mp4"},
+		},
+		{
+			Name:            "mp4_1080p",
+			ProviderMapping: map[string]string{Name: "mp4_1080p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: ""},
+		},
+		{
+			Name:            "hls_360p",
+			ProviderMapping: map[string]string{Name: "hls_360p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: "hls"},
+		},
+		{
+			Name:            "hls_480p",
+			ProviderMapping: map[string]string{Name: "hls_480p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: "ts"},
+		},
+		{
+			Name:            "hls_720p",
+			ProviderMapping: map[string]string{Name: "hls_720p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: "m3u8"},
+		},
+		{
+			Name:            "hls_1080p",
+			ProviderMapping: map[string]string{Name: "hls_1080p", "other": "not relevant"},
+			OutputOpts:      db.OutputOptions{Extension: ".ts"},
+		},
+	}
+	transcodeProfile := provider.TranscodeProfile{
+		SourceMedia: source,
+		Presets:     presets,
+		StreamingParams: provider.StreamingParams{
+			Protocol:        "hls",
+			SegmentDuration: 3,
+		},
+	}
+	newJob, err := presetProvider.newJob(&db.Job{ID: "job-3"}, transcodeProfile)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedJob := elementalconductor.Job{
+		XMLName: xml.Name{
+			Local: "job",
+		},
+		Input: elementalconductor.Input{
+			FileInput: elementalconductor.Location{
+				URI:      "http://some.nice/video.mov",
+				Username: "aws-access-key",
+				Password: "aws-secret-key",
+			},
+		},
+		Priority: 50,
+		OutputGroup: []elementalconductor.OutputGroup{
+			{
+				Order: 1,
+				AppleLiveGroupSettings: &elementalconductor.AppleLiveGroupSettings{
+					Destination: &elementalconductor.Location{
+						URI:      "s3://destination/job-3/video",
+						Username: "aws-access-key",
+						Password: "aws-secret-key",
+					},
+					SegmentDuration: 3,
+				},
+				Type: elementalconductor.AppleLiveOutputGroupType,
+				Output: []elementalconductor.Output{
+					{
+						StreamAssemblyName: "stream_3",
+						NameModifier:       "_hls_360p",
+						Order:              3,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_4",
+						NameModifier:       "_hls_480p",
+						Order:              4,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_5",
+						NameModifier:       "_hls_720p",
+						Order:              5,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+					{
+						StreamAssemblyName: "stream_6",
+						NameModifier:       "_hls_1080p",
+						Order:              6,
+						Container:          elementalconductor.AppleHTTPLiveStreaming,
+					},
+				},
+			},
+			{
+				Order: 2,
+				FileGroupSettings: &elementalconductor.FileGroupSettings{
+					Destination: &elementalconductor.Location{
+						URI:      "s3://destination/job-3/video",
+						Username: "aws-access-key",
+						Password: "aws-secret-key",
+					},
+				},
+				Type: elementalconductor.FileOutputGroupType,
+				Output: []elementalconductor.Output{
+					{
+						StreamAssemblyName: "stream_0",
+						NameModifier:       "_webm_720p",
+						Order:              0,
+						Container:          elementalconductor.Container("webm"),
+					},
+					{
+						StreamAssemblyName: "stream_1",
+						NameModifier:       "_mp4_720p",
+						Order:              1,
+						Container:          elementalconductor.MPEG4,
+					},
+					{
+						StreamAssemblyName: "stream_2",
+						NameModifier:       "_mp4_1080p",
+						Order:              2,
+						Container:          "",
+					},
+				},
+			},
+		},
+		StreamAssembly: []elementalconductor.StreamAssembly{
+			{
+				Name:   "stream_0",
+				Preset: "webm_720p",
+			},
+			{
+				Name:   "stream_1",
+				Preset: "mp4_720p",
+			},
+			{
+				Name:   "stream_2",
+				Preset: "mp4_1080p",
+			},
+			{
+				Name:   "stream_3",
+				Preset: "hls_360p",
+			},
+			{
+				Name:   "stream_4",
+				Preset: "hls_480p",
+			},
+			{
+				Name:   "stream_5",
+				Preset: "hls_720p",
+			},
+			{
+				Name:   "stream_6",
+				Preset: "hls_1080p",
+			},
+		},
+	}
+	if !reflect.DeepEqual(&expectedJob, newJob) {
+		t.Errorf("New adaptive and non-adaptive bitrate job not according to spec.\nWanted %#v.\nGot    %#v.", &expectedJob, newJob)
 	}
 }
 

--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -68,6 +68,10 @@ func (e *encodingComProvider) CreatePreset(preset provider.Preset) (string, erro
 	return "", errors.New("CreatePreset is not implemented in Encoding.com provider")
 }
 
+func (e *encodingComProvider) GetPreset(presetID string) (interface{}, error) {
+	return nil, errors.New("GetPreset is not implemented in Encoding.com provider")
+}
+
 func (e *encodingComProvider) DeletePreset(presetID string) error {
 	return errors.New("DeletePreset is not implemented in Encoding.com provider")
 }

--- a/provider/fake_provider_test.go
+++ b/provider/fake_provider_test.go
@@ -22,6 +22,10 @@ func (*fakeProvider) CreatePreset(Preset) (string, error) {
 	return "", nil
 }
 
+func (*fakeProvider) GetPreset(string) (interface{}, error) {
+	return "", nil
+}
+
 func (*fakeProvider) DeletePreset(string) error {
 	return nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -33,6 +33,7 @@ type TranscodingProvider interface {
 	JobStatus(id string) (*JobStatus, error)
 	CreatePreset(Preset) (string, error)
 	DeletePreset(presetID string) error
+	GetPreset(presetID string) (interface{}, error)
 
 	// Healthcheck should return nil if the provider is currently available
 	// for transcoding videos, otherwise it should return an error

--- a/service/fake_provider_test.go
+++ b/service/fake_provider_test.go
@@ -33,6 +33,10 @@ func (*fakeProvider) CreatePreset(preset provider.Preset) (string, error) {
 	return "presetID_here", nil
 }
 
+func (*fakeProvider) GetPreset(presetID string) (interface{}, error) {
+	return struct{ presetID string }{"presetID_here"}, nil
+}
+
 func (*fakeProvider) DeletePreset(presetID string) error {
 	return nil
 }


### PR DESCRIPTION
For Elemental and AWS Elastic Transcoder, support jobs with a mix of adaptive and non-adaptive streaming presets.
- On AWS Elastic Transcoder, it meant retrieving information on the presets used and creating a playlist for the output of presets where the container is "ts". Also, the name of the playlist must match the name of the outputs, which include the job id, otherwise AWS returns the error `ValidationException: All outputs in a playlist must begin identically to the playlist name upto the last / character.`
- On Elemental, it meant retrieving information on the presets used and creating a separate output group for presets where the container is "m3u8". This depends on multiple output group support added by NYTimes/encoding-wrapper#30.
