### PR TITLE
Fix output destination logic for Elemental provider

### DIFF
--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -135,18 +135,17 @@ func (p *elementalConductorProvider) JobStatus(id string) (*provider.JobStatus, 
 
 func (p *elementalConductorProvider) getOutputDestination(job *elementalconductor.Job) string {
 	destinationPrefix := ""
-	var destinationList []string
+	destination := ""
 	for _, outputGroup := range job.OutputGroup {
 		if outputGroup.Type == elementalconductor.FileOutputGroupType {
 			destinationPrefix = outputGroup.FileGroupSettings.Destination.URI
 		} else {
 			destinationPrefix = outputGroup.AppleLiveGroupSettings.Destination.URI
 		}
-		destination := strings.Split(destinationPrefix, "/")
-		destinationList = append(destinationList, strings.Join(destination[:len(destination)-1], "/"))
+		destinationParts := strings.Split(destinationPrefix, "/")
+		destination = strings.Join(destinationParts[:len(destinationParts)-1], "/")
 	}
-	destinationString, _ := xml.Marshal(destinationList)
-	return string(destinationString)
+	return destination
 }
 
 func (p *elementalConductorProvider) statusMap(elementalConductorStatus string) provider.Status {

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -556,6 +556,61 @@ func TestElementalNewJobPresetNotFound(t *testing.T) {
 	}
 }
 
+func TestJobStatusOutputDestination(t *testing.T) {
+	var tests = []struct {
+		job      elementalconductor.Job
+		expected string
+	}{
+		{
+			elementalconductor.Job{
+				OutputGroup: []elementalconductor.OutputGroup{
+					{
+						Type: elementalconductor.FileOutputGroupType,
+						FileGroupSettings: &elementalconductor.FileGroupSettings{
+							Destination: &elementalconductor.Location{
+								URI: "some/dir/file.mp4",
+							},
+						},
+					}, {
+						Type: elementalconductor.AppleLiveOutputGroupType,
+						AppleLiveGroupSettings: &elementalconductor.AppleLiveGroupSettings{
+							Destination: &elementalconductor.Location{
+								URI: "some/dir/master.m3u8",
+							},
+						},
+					},
+				},
+			},
+			"some/dir",
+		},
+	}
+	elementalConductorConfig := config.Config{
+		ElementalConductor: &config.ElementalConductor{
+			Host:            "https://mybucket.s3.amazonaws.com/destination-dir/",
+			UserLogin:       "myuser",
+			APIKey:          "elemental-api-key",
+			AuthExpires:     30,
+			AccessKeyID:     "aws-access-key",
+			SecretAccessKey: "aws-secret-key",
+			Destination:     "s3://destination",
+		},
+	}
+	prov, err := fakeElementalConductorFactory(&elementalConductorConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	presetProvider, ok := prov.(*elementalConductorProvider)
+	if !ok {
+		t.Fatal("Could not type assert test provider to elementalConductorProvider")
+	}
+	for _, test := range tests {
+		got := presetProvider.getOutputDestination(&test.job)
+		if got != test.expected {
+			t.Errorf("Wrong output destination. Want %q. Got %q", test.expected, got)
+		}
+	}
+}
+
 func TestJobStatusMap(t *testing.T) {
 	var tests = []struct {
 		elementalConductorStatus string


### PR DESCRIPTION
`OutputDestination` on `provider.JobStatus` is a single string, so now the Elemental provider logic assumes that the destination for multiple output groups is the same so it just picks the first one it finds and sets that as the job's output destination.
