### PR TITLE
Fix elastictranscoder output destination

### DIFF
--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -280,7 +280,7 @@ func (p *awsProvider) getOutputDestination(job *elastictranscoder.Job) (string, 
 			*output.Key,
 		)
 		destination := strings.Split(destinationFile, "/")
-		destination = destination[:len(destination)-2]
+		destination = destination[:len(destination)-3]
 		return strings.Join(destination, "/"), nil
 	}
 	return "", nil

--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -134,18 +134,17 @@ func (p *elementalConductorProvider) JobStatus(id string) (*provider.JobStatus, 
 }
 
 func (p *elementalConductorProvider) getOutputDestination(job *elementalconductor.Job) string {
-	destinationPrefix := ""
-	destination := ""
 	for _, outputGroup := range job.OutputGroup {
+		destinationPrefix := ""
 		if outputGroup.Type == elementalconductor.FileOutputGroupType {
 			destinationPrefix = outputGroup.FileGroupSettings.Destination.URI
 		} else {
 			destinationPrefix = outputGroup.AppleLiveGroupSettings.Destination.URI
 		}
 		destinationParts := strings.Split(destinationPrefix, "/")
-		destination = strings.Join(destinationParts[:len(destinationParts)-1], "/")
+		return strings.Join(destinationParts[:len(destinationParts)-1], "/")
 	}
-	return destination
+	return ""
 }
 
 func (p *elementalConductorProvider) statusMap(elementalConductorStatus string) provider.Status {


### PR DESCRIPTION
- Fix elastic transcoder output destination so that it includes both adaptive and non-adaptive streaming output.
- Do not change behavior, but refactor elemental conductor output destination logic to be more clear.
