### PR TITLE
provider/encodingcom: respect api standard s3 format in output as well

### DIFF
--- a/provider/encodingcom/encodingcom_server_test.go
+++ b/provider/encodingcom/encodingcom_server_test.go
@@ -86,7 +86,7 @@ func (c *encodingComFakeClient) GetStatus(mediaIDs []string) ([]encodingcom.Stat
 			{
 				Destinations: []encodingcom.DestinationStatus{
 					{
-						Name:   "s3://mybucket/dir/file.mp4",
+						Name:   "https://mybucket.s3.amazonaws.com/dir/file.mp4",
 						Status: "Saved",
 					},
 				},


### PR DESCRIPTION
Similar to the change merged in #74, but #74 was about the input media,
and this is about the output media.
