### PR TITLE
service: add endpoint to cancel jobs

### DIFF
--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -301,6 +301,11 @@ func (p *awsProvider) statusMap(awsStatus string) provider.Status {
 	}
 }
 
+func (p *awsProvider) CancelJob(id string) error {
+	_, err := p.c.CancelJob(&elastictranscoder.CancelJobInput{Id: aws.String(id)})
+	return err
+}
+
 func (p *awsProvider) Healthcheck() error {
 	_, err := p.c.ReadPipeline(&elastictranscoder.ReadPipelineInput{
 		Id: aws.String(p.config.PipelineID),

--- a/provider/elementalconductor/client.go
+++ b/provider/elementalconductor/client.go
@@ -1,0 +1,17 @@
+package elementalconductor
+
+import "github.com/NYTimes/encoding-wrapper/elementalconductor"
+
+type clientInterface interface {
+	GetPreset(presetID string) (*elementalconductor.Preset, error)
+	CreatePreset(preset *elementalconductor.Preset) (*elementalconductor.Preset, error)
+	DeletePreset(presetID string) error
+	CreateJob(job *elementalconductor.Job) (*elementalconductor.Job, error)
+	GetJob(jobID string) (*elementalconductor.Job, error)
+	CancelJob(jobID string) (*elementalconductor.Job, error)
+	GetNodes() ([]elementalconductor.Node, error)
+	GetCloudConfig() (*elementalconductor.CloudConfig, error)
+	GetAccessKeyID() string
+	GetSecretAccessKey() string
+	GetDestination() string
+}

--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -43,7 +43,7 @@ func init() {
 
 type elementalConductorProvider struct {
 	config *config.Config
-	client elementalconductor.ClientInterface
+	client clientInterface
 }
 
 func (p *elementalConductorProvider) DeletePreset(presetID string) error {
@@ -267,6 +267,11 @@ func (p *elementalConductorProvider) newJob(job *db.Job, transcodeProfile provid
 		StreamAssembly: streamAssemblyList,
 	}
 	return &newJob, nil
+}
+
+func (p *elementalConductorProvider) CancelJob(id string) error {
+	_, err := p.client.CancelJob(id)
+	return err
 }
 
 func (p *elementalConductorProvider) Healthcheck() error {

--- a/provider/elementalconductor/elementalconductor_fake_transcode_test.go
+++ b/provider/elementalconductor/elementalconductor_fake_transcode_test.go
@@ -10,6 +10,7 @@ import (
 
 type fakeElementalConductorClient struct {
 	*elementalconductor.Client
+	canceledJobs []string
 }
 
 func newFakeElementalConductorClient(cfg *config.Config) *fakeElementalConductorClient {
@@ -29,9 +30,11 @@ func newFakeElementalConductorClient(cfg *config.Config) *fakeElementalConductor
 func (c *fakeElementalConductorClient) GetAccessKeyID() string {
 	return c.AccessKeyID
 }
+
 func (c *fakeElementalConductorClient) GetSecretAccessKey() string {
 	return c.SecretAccessKey
 }
+
 func (c *fakeElementalConductorClient) GetDestination() string {
 	return c.Destination
 }
@@ -46,25 +49,16 @@ func (c *fakeElementalConductorClient) GetPreset(presetID string) (*elementalcon
 		Container: string(container),
 	}, nil
 }
+
 func (c *fakeElementalConductorClient) CreatePreset(preset *elementalconductor.Preset) (*elementalconductor.Preset, error) {
 	return &elementalconductor.Preset{
 		Name: preset.Name,
 	}, nil
 }
-func (c *fakeElementalConductorClient) DeletePreset(presetID string) error {
-	return nil
-}
-func (c *fakeElementalConductorClient) CreateJob(job *elementalconductor.Job) (*elementalconductor.Job, error) {
+
+func (c *fakeElementalConductorClient) CancelJob(jobID string) (*elementalconductor.Job, error) {
+	c.canceledJobs = append(c.canceledJobs, jobID)
 	return &elementalconductor.Job{}, nil
-}
-func (c *fakeElementalConductorClient) GetJob(jobID string) (*elementalconductor.Job, error) {
-	return &elementalconductor.Job{}, nil
-}
-func (c *fakeElementalConductorClient) GetNodes() ([]elementalconductor.Node, error) {
-	return []elementalconductor.Node{}, nil
-}
-func (c *fakeElementalConductorClient) GetCloudConfig() (*elementalconductor.CloudConfig, error) {
-	return &elementalconductor.CloudConfig{}, nil
 }
 
 func fakeElementalConductorFactory(cfg *config.Config) (provider.TranscodingProvider, error) {

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -635,6 +635,32 @@ func TestJobStatusMap(t *testing.T) {
 	}
 }
 
+func TestCancelJob(t *testing.T) {
+	elementalConductorConfig := config.Config{
+		ElementalConductor: &config.ElementalConductor{
+			Host:            "https://mybucket.s3.amazonaws.com/destination-dir/",
+			UserLogin:       "myuser",
+			APIKey:          "elemental-api-key",
+			AuthExpires:     30,
+			AccessKeyID:     "aws-access-key",
+			SecretAccessKey: "aws-secret-key",
+			Destination:     "s3://destination",
+		},
+	}
+	prov, err := fakeElementalConductorFactory(&elementalConductorConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = prov.CancelJob("idk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := prov.(*elementalConductorProvider).client.(*fakeElementalConductorClient)
+	if client.canceledJobs[0] != "idk" {
+		t.Errorf("did not cancel the correct job. Want %q. Got %q", "idk", client.canceledJobs[0])
+	}
+}
+
 func TestHealthcheck(t *testing.T) {
 	server := NewElementalServer(nil, nil)
 	defer server.Close()

--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -47,6 +47,7 @@ func init() {
 
 type encodingComClient interface {
 	AddMedia(source []string, format []encodingcom.Format, Region string) (*encodingcom.AddMediaResponse, error)
+	CancelMedia(string) (*encodingcom.Response, error)
 	GetStatus(mediaIDs []string) ([]encodingcom.StatusResponse, error)
 	SavePreset(name string, format encodingcom.Format) (*encodingcom.SavePresetResponse, error)
 	GetPreset(name string) (*encodingcom.Preset, error)
@@ -313,6 +314,11 @@ func (e *encodingComProvider) statusMap(encodingComStatus string) provider.Statu
 	default:
 		return provider.StatusUnknown
 	}
+}
+
+func (e *encodingComProvider) CancelJob(id string) error {
+	_, err := e.client.CancelMedia(id)
+	return err
 }
 
 func (e *encodingComProvider) Healthcheck() error {

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -612,6 +612,30 @@ func TestDeletePresetNotFound(t *testing.T) {
 	}
 }
 
+func TestCancelJob(t *testing.T) {
+	server := newEncodingComFakeServer()
+	defer server.Close()
+	now := time.Now().UTC().Truncate(time.Second)
+	media := fakeMedia{
+		ID:       "mymedia",
+		Status:   "Finished",
+		Created:  now.Add(-time.Hour),
+		Started:  now.Add(-50 * time.Minute),
+		Finished: now.Add(-10 * time.Minute),
+	}
+	server.medias["mymedia"] = &media
+	client := newEncodingComFakeClient(media)
+	client.Client.Endpoint = server.URL
+	prov := encodingComProvider{client: client}
+	err := prov.CancelJob("mymedia")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if media.Status != "Canceled" {
+		t.Errorf("wrong status. Want %q. Got %q", "Canceled", media.Status)
+	}
+}
+
 func TestHealthcheck(t *testing.T) {
 	server := newEncodingComFakeServer()
 	defer server.Close()

--- a/provider/fake_provider_test.go
+++ b/provider/fake_provider_test.go
@@ -30,6 +30,10 @@ func (*fakeProvider) DeletePreset(string) error {
 	return nil
 }
 
+func (*fakeProvider) CancelJob(string) error {
+	return nil
+}
+
 func (f *fakeProvider) Healthcheck() error {
 	return f.healthErr
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -31,6 +31,7 @@ var (
 type TranscodingProvider interface {
 	Transcode(*db.Job, TranscodeProfile) (*JobStatus, error)
 	JobStatus(id string) (*JobStatus, error)
+	CancelJob(id string) error
 	CreatePreset(Preset) (string, error)
 	DeletePreset(presetID string) error
 	GetPreset(presetID string) (interface{}, error)

--- a/service/service.go
+++ b/service/service.go
@@ -62,6 +62,9 @@ func (s *TranscodingService) JSONEndpoints() map[string]map[string]server.JSONEn
 		"/jobs/:jobId": {
 			"GET": swagger.HandlerToJSONEndpoint(s.getTranscodeJob),
 		},
+		"/jobs/:jobId/cancel": {
+			"POST": swagger.HandlerToJSONEndpoint(s.cancelTranscodeJob),
+		},
 		"/presets": {
 			"POST": swagger.HandlerToJSONEndpoint(s.newPreset),
 		},

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -93,3 +93,8 @@ type getTranscodeJobInput struct {
 func (p *getTranscodeJobInput) loadParams(paramsMap map[string]string) {
 	p.JobID = paramsMap["jobId"]
 }
+
+// swagger:parameters cancelJob
+type cancelTranscodeJobInput struct {
+	getTranscodeJobInput
+}


### PR DESCRIPTION
Currently, all of our providers can't cancel jobs that are processing,
but it's possible to cancel the jobs when they are queued.
