### PR TITLE
provider/encodingcom: fix output destination in JobStatus

### DIFF
--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -244,7 +244,8 @@ func (p *awsProvider) DeletePreset(presetID string) error {
 	return err
 }
 
-func (p *awsProvider) JobStatus(id string) (*provider.JobStatus, error) {
+func (p *awsProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
+	id := job.ProviderJobID
 	resp, err := p.c.ReadJob(&elastictranscoder.ReadJobInput{Id: aws.String(id)})
 	if err != nil {
 		return nil, err

--- a/provider/elastictranscoder/aws_test.go
+++ b/provider/elastictranscoder/aws_test.go
@@ -595,13 +595,12 @@ func TestAWSJobStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id := jobStatus.ProviderJobID
-	jobStatus, err = prov.JobStatus(id)
+	jobStatus, err = prov.JobStatus(&db.Job{ProviderJobID: jobStatus.ProviderJobID})
 	if err != nil {
 		t.Fatal(err)
 	}
 	expectedJobStatus := provider.JobStatus{
-		ProviderJobID: id,
+		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
@@ -668,7 +667,7 @@ func TestAWSJobStatusNotFound(t *testing.T) {
 			PipelineID:      "mypipeline",
 		},
 	}
-	jobStatus, err := provider.JobStatus("idk")
+	jobStatus, err := provider.JobStatus(&db.Job{ProviderJobID: "idk"})
 	if err == nil {
 		t.Fatal("Got unexpected <nil> error")
 	}
@@ -694,7 +693,7 @@ func TestAWSJobStatusInternalError(t *testing.T) {
 			PipelineID:      "mypipeline",
 		},
 	}
-	jobStatus, err := provider.JobStatus("idk")
+	jobStatus, err := provider.JobStatus(&db.Job{ProviderJobID: "idk"})
 	if jobStatus != nil {
 		t.Errorf("Got unexpected non-nil JobStatus: %#v", jobStatus)
 	}

--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -102,8 +102,8 @@ func (p *elementalConductorProvider) Transcode(job *db.Job, transcodeProfile pro
 	}, nil
 }
 
-func (p *elementalConductorProvider) JobStatus(id string) (*provider.JobStatus, error) {
-	resp, err := p.client.GetJob(id)
+func (p *elementalConductorProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
+	resp, err := p.client.GetJob(job.ProviderJobID)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (p *elementalConductorProvider) JobStatus(id string) (*provider.JobStatus, 
 	}
 	return &provider.JobStatus{
 		ProviderName:      Name,
-		ProviderJobID:     id,
+		ProviderJobID:     job.ProviderJobID,
 		Progress:          float64(resp.PercentComplete),
 		Status:            p.statusMap(resp.Status),
 		ProviderStatus:    providerStatus,

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -657,7 +657,7 @@ func TestJobStatus(t *testing.T) {
 		Submitted:       submitted,
 	}
 	prov := elementalConductorProvider{client: client, config: &elementalConductorConfig}
-	jobStatus, err := prov.JobStatus("job-1")
+	jobStatus, err := prov.JobStatus(&db.Job{ProviderJobID: "job-1"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/provider/encodingcom/encodingcom_server_test.go
+++ b/provider/encodingcom/encodingcom_server_test.go
@@ -190,8 +190,8 @@ func (s *encodingComFakeServer) getStatus(w http.ResponseWriter, req request) {
 			"output":     "advanced_hls",
 			"format": map[string]interface{}{
 				"destination": []string{
-					"https://mybucket.s3.amazonaws.com/dir/some_hls_preset/video-0.m3u8",
-					"https://mybucket.s3.amazonaws.com/dir/video.m3u8",
+					"https://mybucket.s3.amazonaws.com/dir/job-123/some_hls_preset/video-0.m3u8",
+					"https://mybucket.s3.amazonaws.com/dir/job-123/video.m3u8",
 				},
 				"destination_status": []string{"Saved", "Saved"},
 				"size":               media.Request.Format[0].Size,

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -409,10 +409,10 @@ func TestJobStatus(t *testing.T) {
 	prov := encodingComProvider{client: client}
 	prov.config = &config.Config{
 		EncodingCom: &config.EncodingCom{
-			Destination: "mybucket",
+			Destination: "https://mybucket.s3.amazonaws.com/dir/",
 		},
 	}
-	jobStatus, err := prov.JobStatus("mymedia")
+	jobStatus, err := prov.JobStatus(&db.Job{ID: "job-123", ProviderJobID: "mymedia"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestJobStatus(t *testing.T) {
 			"destinationStatus": []destinationStatus{
 				{
 					DestinationStatus: encodingcom.DestinationStatus{
-						Name:   "s3://mybucket/dir/some_hls_preset/video-0.m3u8",
+						Name:   "s3://mybucket/dir/job-123/some_hls_preset/video-0.m3u8",
 						Status: "Saved",
 					},
 					Size:       "1920x1080",
@@ -442,7 +442,7 @@ func TestJobStatus(t *testing.T) {
 				},
 				{
 					DestinationStatus: encodingcom.DestinationStatus{
-						Name:   "s3://mybucket/dir/video.m3u8",
+						Name:   "s3://mybucket/dir/job-123/video.m3u8",
 						Status: "Saved",
 					},
 					Size:       "1920x1080",
@@ -457,7 +457,7 @@ func TestJobStatus(t *testing.T) {
 			Height:     1080,
 			VideoCodec: "VP9",
 		},
-		OutputDestination: "s3://mybucket/dir/some_hls_preset",
+		OutputDestination: "s3://mybucket/dir/job-123/",
 	}
 	if !reflect.DeepEqual(*jobStatus, expected) {
 		t.Errorf("JobStatus: wrong job returned.\nWant %#v\nGot  %#v", expected, *jobStatus)
@@ -492,10 +492,10 @@ func TestJobStatusNotFinished(t *testing.T) {
 	prov := encodingComProvider{client: client}
 	prov.config = &config.Config{
 		EncodingCom: &config.EncodingCom{
-			Destination: "mybucket",
+			Destination: "https://mybucket.s3.amazonaws.com/dir/",
 		},
 	}
-	jobStatus, err := prov.JobStatus("mymedia")
+	jobStatus, err := prov.JobStatus(&db.Job{ID: "job-123", ProviderJobID: "mymedia"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +516,7 @@ func TestJobStatusNotFinished(t *testing.T) {
 			"destinationStatus": []destinationStatus{
 				{
 					DestinationStatus: encodingcom.DestinationStatus{
-						Name:   "s3://mybucket/dir/some_hls_preset/video-0.m3u8",
+						Name:   "s3://mybucket/dir/job-123/some_hls_preset/video-0.m3u8",
 						Status: "Saved",
 					},
 					Size:       "1920x1080",
@@ -525,7 +525,7 @@ func TestJobStatusNotFinished(t *testing.T) {
 				},
 				{
 					DestinationStatus: encodingcom.DestinationStatus{
-						Name:   "s3://mybucket/dir/video.m3u8",
+						Name:   "s3://mybucket/dir/job-123/video.m3u8",
 						Status: "Saved",
 					},
 					Size:       "1920x1080",
@@ -534,7 +534,7 @@ func TestJobStatusNotFinished(t *testing.T) {
 				},
 			},
 		},
-		OutputDestination: "s3://mybucket/dir/some_hls_preset",
+		OutputDestination: "s3://mybucket/dir/job-123/",
 	}
 	if !reflect.DeepEqual(*jobStatus, expected) {
 		t.Errorf("JobStatus: wrong job returned.\nWant %#v.\nGot  %#v.", expected, *jobStatus)
@@ -633,7 +633,7 @@ func TestJobStatusInvalidMediaInfo(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		jobStatus, err := prov.JobStatus(test.mediaID)
+		jobStatus, err := prov.JobStatus(&db.Job{ProviderJobID: test.mediaID})
 		if jobStatus != nil {
 			t.Errorf("%s: got unexpected non-nil status: %#v", test.testCase, jobStatus)
 		}
@@ -652,7 +652,7 @@ func TestJobStatusMediaNotFound(t *testing.T) {
 	defer server.Close()
 	client, _ := encodingcom.NewClient(server.URL, "myuser", "secret")
 	provider := encodingComProvider{client: client}
-	jobStatus, err := provider.JobStatus("non-existent-job")
+	jobStatus, err := provider.JobStatus(&db.Job{ProviderJobID: "non-existent-job"})
 	if err == nil {
 		t.Errorf("JobStatus: got unexpected <nil> err.")
 	}

--- a/provider/fake_provider_test.go
+++ b/provider/fake_provider_test.go
@@ -14,7 +14,7 @@ func (*fakeProvider) Transcode(*db.Job, TranscodeProfile) (*JobStatus, error) {
 	return nil, nil
 }
 
-func (*fakeProvider) JobStatus(string) (*JobStatus, error) {
+func (*fakeProvider) JobStatus(*db.Job) (*JobStatus, error) {
 	return nil, nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -31,7 +31,7 @@ var (
 // might be a JSON, or an XML, or anything else.
 type TranscodingProvider interface {
 	Transcode(*db.Job, TranscodeProfile) (*JobStatus, error)
-	JobStatus(id string) (*JobStatus, error)
+	JobStatus(*db.Job) (*JobStatus, error)
 	CancelJob(id string) error
 	CreatePreset(Preset) (string, error)
 	DeletePreset(presetID string) error

--- a/service/fake_provider_test.go
+++ b/service/fake_provider_test.go
@@ -45,7 +45,8 @@ func (*fakeProvider) DeletePreset(presetID string) error {
 	return nil
 }
 
-func (p *fakeProvider) JobStatus(id string) (*provider.JobStatus, error) {
+func (p *fakeProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
+	id := job.ProviderJobID
 	if id == "provider-job-123" {
 		status := provider.StatusFinished
 		if len(p.canceledJobs) > 0 {

--- a/service/transcode.go
+++ b/service/transcode.go
@@ -143,7 +143,7 @@ func (s *TranscodingService) getTranscodeJobByID(jobID string) (*db.Job, *provid
 	if err != nil {
 		return job, nil, nil, fmt.Errorf("error initializing provider %q on job id %q: %s %s", job.ProviderName, jobID, providerObj, err)
 	}
-	jobStatus, err := providerObj.JobStatus(job.ProviderJobID)
+	jobStatus, err := providerObj.JobStatus(job)
 	if err != nil {
 		return job, nil, providerObj, err
 	}
@@ -177,7 +177,7 @@ func (s *TranscodingService) cancelTranscodeJob(r *http.Request) swagger.GizmoJS
 	if err != nil {
 		return swagger.NewErrorResponse(err)
 	}
-	status, err := prov.JobStatus(job.ProviderJobID)
+	status, err := prov.JobStatus(job)
 	if err != nil {
 		return swagger.NewErrorResponse(err)
 	}


### PR DESCRIPTION
Instead of trying to "guess" what's the output, just reassemble the same
thing that we used on creation (which is the base destination + job id).

I'll also properly fix this in other providers as part of the work in
PR #85.
