### PR TITLE
provider/encodingcom: add ?nocopy to s3 source

### DIFF
--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -35,7 +35,7 @@ const Name = "encodingcom"
 
 var (
 	kregexp      = regexp.MustCompile(`000$`)
-	s3regexp     = regexp.MustCompile(`^s3://([^/_.]+)/(.+)$`)
+	s3regexp     = regexp.MustCompile(`^s3://([^/_.]+)/([^?]+)(\?.+)?$`)
 	httpS3Regexp = regexp.MustCompile(`https?://([^/_.]+)\.s3\.amazonaws\.com/(.+)$`)
 )
 
@@ -79,7 +79,11 @@ func (e *encodingComProvider) CreatePreset(preset provider.Preset) (string, erro
 func (e *encodingComProvider) sourceMedia(original string) string {
 	parts := s3regexp.FindStringSubmatch(original)
 	if len(parts) > 0 {
-		return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", parts[1], parts[2])
+		qs := parts[3]
+		if qs == "" {
+			qs = "?nocopy"
+		}
+		return fmt.Sprintf("https://%s.s3.amazonaws.com/%s%s", parts[1], parts[2], qs)
 	}
 	return original
 }

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -284,7 +284,79 @@ func TestEncodingComS3Input(t *testing.T) {
 		},
 	}
 	source := "s3://mybucket/directory/video.mp4"
-	expectedSource := "https://mybucket.s3.amazonaws.com/directory/video.mp4"
+	expectedSource := "https://mybucket.s3.amazonaws.com/directory/video.mp4?nocopy"
+	presets := []db.PresetMap{
+		{
+			Name: "webm_720p",
+			ProviderMapping: map[string]string{
+				Name:           "123455",
+				"not-relevant": "something",
+			},
+			OutputOpts: db.OutputOptions{Extension: "webm"},
+		},
+	}
+	outputs := make([]provider.TranscodeOutput, len(presets))
+	for i, preset := range presets {
+		_, err := prov.CreatePreset(provider.Preset{
+			Name:      preset.ProviderMapping[Name],
+			Container: preset.OutputOpts.Extension,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		outputs[i] = provider.TranscodeOutput{
+			Preset:   preset,
+			FileName: "best-video-ever." + preset.OutputOpts.Extension,
+		}
+	}
+
+	transcodeProfile := provider.TranscodeProfile{
+		SourceMedia: source,
+		Outputs:     outputs,
+	}
+	jobStatus, err := prov.Transcode(&db.Job{ID: "job-123"}, transcodeProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := "it worked"; jobStatus.StatusMessage != expected {
+		t.Errorf("wrong StatusMessage. Want %q. Got %q", expected, jobStatus.StatusMessage)
+	}
+	if jobStatus.ProviderName != Name {
+		t.Errorf("wrong ProviderName. Want %q. Got %q", Name, jobStatus.ProviderName)
+	}
+	media, err := server.getMedia(jobStatus.ProviderJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest := prov.config.EncodingCom.Destination
+	expectedFormats := []encodingcom.Format{
+		{
+			OutputPreset: "123455",
+			Destination:  []string{dest + "job-123/best-video-ever.webm"},
+		},
+	}
+	if !reflect.DeepEqual(media.Request.Format, expectedFormats) {
+		t.Errorf("Wrong format.\nWant %#v\nGot  %#v.", expectedFormats, media.Request.Format)
+	}
+	if !reflect.DeepEqual([]string{expectedSource}, media.Request.Source) {
+		t.Errorf("Wrong source. Want %v. Got %v.", []string{expectedSource}, media.Request.Source)
+	}
+}
+
+func TestEncodingComS3InputWithNoCopy(t *testing.T) {
+	server := newEncodingComFakeServer()
+	defer server.Close()
+	client, _ := encodingcom.NewClient(server.URL, "myuser", "secret")
+	prov := encodingComProvider{
+		client: client,
+		config: &config.Config{
+			EncodingCom: &config.EncodingCom{
+				Destination: "https://mybucket.s3.amazonaws.com/destination-dir/",
+			},
+		},
+	}
+	source := "s3://mybucket/directory/video.mp4?nocopy"
+	expectedSource := "https://mybucket.s3.amazonaws.com/directory/video.mp4?nocopy"
 	presets := []db.PresetMap{
 		{
 			Name: "webm_720p",


### PR DESCRIPTION
We don't want to require clients to provide this, and there's no reason
for not using it if the source media comes from S3.
