### PR TITLE
Add StackDriver logging hook

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/NYTimes/gizmo/config"
 	"github.com/NYTimes/gizmo/server"
+	"github.com/marzagao/envconfigfromfile"
 	"github.com/nytm/video-transcoding-api/db/redis/storage"
 )
 
@@ -16,6 +17,7 @@ type Config struct {
 	EncodingCom            *EncodingCom
 	ElasticTranscoder      *ElasticTranscoder
 	ElementalConductor     *ElementalConductor
+	GCPCredentials         *envconfigfromfile.EnvConfigFromFile `envconfig:"GCP_CREDENTIALS_FILE"`
 }
 
 // EncodingCom represents the set of configurations for the Encoding.com

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,17 +1,21 @@
 package config
 
 import (
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
 	"github.com/NYTimes/gizmo/server"
+	"github.com/marzagao/envconfigfromfile"
 	"github.com/nytm/video-transcoding-api/db/redis/storage"
 )
 
 func TestLoadConfigFromEnv(t *testing.T) {
 	os.Clearenv()
 	accessLog := "/var/log/transcoding-api-access.log"
+	gcpCredsTestFilePath := "testdata/fake_gcp_creds.json"
+	gcpCredsTestFileContents, _ := ioutil.ReadFile(gcpCredsTestFilePath)
 	setEnvs(map[string]string{
 		"SENTINEL_ADDRS":                           "10.10.10.10:26379,10.10.10.11:26379,10.10.10.12:26379",
 		"SENTINEL_MASTER_NAME":                     "supermaster",
@@ -39,6 +43,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 		"HTTP_ACCESS_LOG":                          accessLog,
 		"HTTP_PORT":                                "8080",
 		"DEFAULT_SEGMENT_DURATION":                 "3",
+		"GCP_CREDENTIALS_FILE":                     gcpCredsTestFilePath,
 	})
 	cfg := LoadConfig()
 	expectedCfg := Config{
@@ -78,6 +83,10 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			HTTPPort:      8080,
 			HTTPAccessLog: &accessLog,
 		},
+		GCPCredentials: &envconfigfromfile.EnvConfigFromFile{
+			FilePath: gcpCredsTestFilePath,
+			Value:    string(gcpCredsTestFileContents),
+		},
 	}
 	if cfg.SwaggerManifest != expectedCfg.SwaggerManifest {
 		t.Errorf("LoadConfig(): wrong swagger manifest. Want %q. Got %q", expectedCfg.SwaggerManifest, cfg.SwaggerManifest)
@@ -96,6 +105,9 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	}
 	if !reflect.DeepEqual(*cfg.ElementalConductor, *expectedCfg.ElementalConductor) {
 		t.Errorf("LoadConfig(): wrong Elemental Conductor config returned. Want %#v. Got %#v.", *expectedCfg.ElementalConductor, *cfg.ElementalConductor)
+	}
+	if !reflect.DeepEqual(*cfg.GCPCredentials, *expectedCfg.GCPCredentials) {
+		t.Errorf("LoadConfig(): Wrong GCPCredentials returned. Want %#v. Got %#v.", *expectedCfg.GCPCredentials, *cfg.GCPCredentials)
 	}
 }
 

--- a/config/testdata/fake_gcp_creds.json
+++ b/config/testdata/fake_gcp_creds.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "some-project",
+  "private_key_id": "some-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nsomething-something-something\n-----END PRIVATE KEY-----\n",
+  "client_email": "email@something.iam.gserviceaccount.com",
+  "client_id": "some-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/email@something.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
- Added Stackdriver logging hook leveraging [envconfigfromfile](https://github.com/marzagao/envconfigfromfile) to get GCP credentials.
- Separately, also added the proper value for `GCP_CREDENTIALS_FILE` in the `.appvars` files of every environment.
