### PR TITLE
pin golangci-lint version

### DIFF
--- a/drone/ci.yml
+++ b/drone/ci.yml
@@ -35,7 +35,7 @@ steps:
 
 - name: lint
   pull: always
-  image: golangci/golangci-lint
+  image: golangci/golangci-lint:v1.21
   commands:
   - make runlint
   depends_on:
@@ -150,7 +150,7 @@ steps:
 
 - name: lint
   pull: always
-  image: golangci/golangci-lint
+  image: golangci/golangci-lint:v1.21
   commands:
   - make runlint
   depends_on:


### PR DESCRIPTION
Similar to https://github.com/nytimes/threeplay/pull/45

Pins the version of golangci-lint so new linter rules don't cause old code to start failing without having changed. We can then add as a cleanup task, fixing (or choosing to ignore) these violations when upgrading the version of the linter.