### PR TITLE
added the mcCfg to the aws mc client for authentication with AWS

### DIFF
--- a/internal/provider/mediaconvert/mediaconvert.go
+++ b/internal/provider/mediaconvert/mediaconvert.go
@@ -387,6 +387,7 @@ func mediaconvertFactory(cfg *config.Config) (provider.TranscodingProvider, erro
 		client: mediaconvert.New(mediaconvert.Options{
 			EndpointResolver: mediaconvert.EndpointResolverFromURL(cfg.MediaConvert.Endpoint),
 			Region:           cfg.MediaConvert.Region,
+			Credentials: mcCfg.Credentials,
 		}),
 		cfg: cfg.MediaConvert,
 	}, nil


### PR DESCRIPTION
What version of Go are you using (go version)?
go1.16.5

What operating system and processor architecture are you using?
macOS Apple M1

What did you do?
I added the aws credential configuration to the aws mediaconvert client's New function. 

What did you expect to see?
I expect to see 200 responses from AWS before this change.

What did you see instead?
Before this change I would only see 403 MissingAuthenticationTokenException: Missing Authentication Token from AWS